### PR TITLE
fix: add support to themes in modal

### DIFF
--- a/app/components/d-combobox.vue
+++ b/app/components/d-combobox.vue
@@ -67,7 +67,7 @@ const handleClear = (e: Event) => {
     :disabled="props.disabled"
   >
     <ComboboxAnchor
-      class="bg-neutral border-neutral hover: flex min-h-[2.25rem] w-full cursor-default items-center justify-between rounded-lg border text-sm outline-none focus:border-blue-600 focus:bg-white focus:ring-2 focus:ring-blue-300"
+      class="bg-neutral border-neutral hover: flex min-h-[2.25rem] w-full cursor-default items-center justify-between rounded-lg border text-sm outline-none focus:border-blue-600 focus:bg-neutral focus:ring-2 focus:ring-blue-300"
       :class="[
         props.disabled
           ? 'cursor-not-allowed bg-neutral-100 opacity-50'

--- a/app/components/d-modal.vue
+++ b/app/components/d-modal.vue
@@ -58,13 +58,13 @@ function confirm() {
           class="data-[state=open]:animate-overlayShow bg-neutral-inverse/5 fixed inset-0 z-10 backdrop-blur-xs"
         />
         <DialogContent
-          class="data-[state=open]:animate-contentShow relative z-20 flex w-full flex-col rounded-lg bg-white shadow-lg outline-none"
+          class="data-[state=open]:animate-contentShow relative z-20 flex w-full flex-col rounded-lg bg-neutral shadow-lg outline-none"
           :class="[sizeClasses[size], 'max-h-[80vh]']"
         >
           <!-- Header -->
           <div class="border-neutral flex items-center justify-between border-b p-5">
             <div>
-              <DialogTitle class="text-lg font-semibold text-neutral-900">
+              <DialogTitle class="text-lg font-semibold text-neutral">
                 {{ title }}
               </DialogTitle>
               <DialogDescription


### PR DESCRIPTION
# Add Theme Support to Modal Components

## What Changed
- Updated styling in multiple components to use the `neutral` color scheme consistently:
  - In `d-combobox.vue`: Changed `focus:bg-white` to `focus:bg-neutral` in the ComboboxAnchor class
  - In `d-modal.vue`: Changed `bg-white` to `bg-neutral` in DialogContent and updated DialogTitle to use `text-neutral` instead of `text-neutral-900`

## Why
This change ensures visual consistency across the application by standardizing the color scheme used in modal components. Using the `neutral` color palette allows for better theming support and a more cohesive user interface.

## Notes for Reviewers
- These changes are styling-only and should not affect component functionality
- Please verify that the components render correctly in both light and dark themes