### PR TITLE
feat: add validation for site deletion to prevent orphaned data

### DIFF
--- a/server/api/sites/[siteId]/components/[componentId]/fields/[fieldId]/index.delete.ts
+++ b/server/api/sites/[siteId]/components/[componentId]/fields/[fieldId]/index.delete.ts
@@ -1,0 +1,82 @@
+import { componentFields, fieldOptions } from "~~/server/database/schema"
+import { and, eq } from "drizzle-orm"
+
+export default defineEventHandler(async (event) => {
+  const { secure } = await requireUserSession(event)
+  if (!secure) throw createError({ statusCode: 401, statusMessage: "Unauthorized" })
+
+  const siteId = getRouterParam(event, "siteId")
+  if (!siteId) throw createError({ statusCode: 400, statusMessage: "siteId is required" })
+
+  const componentId = getRouterParam(event, "componentId")
+  if (!componentId) throw createError({ statusCode: 400, statusMessage: "componentId is required" })
+
+  const fieldId = getRouterParam(event, "fieldId")
+  if (!fieldId) throw createError({ statusCode: 400, statusMessage: "fieldId is required" })
+
+  const db = useDrizzle()
+
+  console.log("Deleting field:", fieldId)
+
+  try {
+    return await db.transaction(async (tx) => {
+      // 1. Check if the field exists and belongs to the correct component/site/org
+      const [existingField] = await tx
+        .select()
+        .from(componentFields)
+        .where(
+          and(
+            eq(componentFields.id, fieldId),
+            eq(componentFields.componentId, componentId),
+            eq(componentFields.siteId, siteId),
+            eq(componentFields.organisationId, secure.organisationId)
+          )
+        )
+
+      if (!existingField) {
+        throw createError({
+          statusCode: 404,
+          statusMessage: "Field not found or you do not have permission to delete it."
+        })
+      }
+
+      // 2. Delete related field options
+      await tx.delete(fieldOptions).where(
+        and(
+          eq(fieldOptions.fieldId, fieldId),
+          eq(fieldOptions.componentId, componentId),
+          eq(fieldOptions.siteId, siteId),
+          eq(fieldOptions.organisationId, secure.organisationId)
+        )
+      )
+
+      // 3. Delete the field
+      const [deletedField] = await tx
+        .delete(componentFields)
+        .where(
+          and(
+            eq(componentFields.id, fieldId),
+            eq(componentFields.componentId, componentId),
+            eq(componentFields.siteId, siteId),
+            eq(componentFields.organisationId, secure.organisationId)
+          )
+        )
+        .returning()
+
+      return deletedField
+    })
+  } catch (error) {
+    console.error("Error deleting field:", error)
+    if (error instanceof Error && error.message.includes("foreign key constraint")) {
+      throw createError({
+        statusCode: 409,
+        statusMessage: "Cannot delete field because it has related data."
+      })
+    }
+
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Internal Server Error"
+    })
+  }
+}) 

--- a/server/api/sites/[siteId]/fields/[fieldId]/index.delete.ts
+++ b/server/api/sites/[siteId]/fields/[fieldId]/index.delete.ts
@@ -1,0 +1,76 @@
+import { fields, fieldOptions } from "~~/server/database/schema"
+import { and, eq } from "drizzle-orm"
+
+export default defineEventHandler(async (event) => {
+  const { secure } = await requireUserSession(event)
+  if (!secure) throw createError({ statusCode: 401, statusMessage: "Unauthorized" })
+
+  const siteId = getRouterParam(event, "siteId")
+  if (!siteId) throw createError({ statusCode: 400, statusMessage: "siteId is required" })
+
+  const fieldId = getRouterParam(event, "fieldId")
+  if (!fieldId) throw createError({ statusCode: 400, statusMessage: "fieldId is required" })
+
+  const db = useDrizzle()
+
+  console.log("Deleting field:", fieldId)
+
+  try {
+    return await db.transaction(async (tx) => {
+      // 1. Check if the field exists and belongs to the correct site/org
+      const [existingField] = await tx
+        .select()
+        .from(fields)
+        .where(
+          and(
+            eq(fields.id, fieldId),
+            eq(fields.siteId, siteId),
+            eq(fields.organisationId, secure.organisationId)
+          )
+        )
+
+      if (!existingField) {
+        throw createError({
+          statusCode: 404,
+          statusMessage: "Field not found or you do not have permission to delete it."
+        })
+      }
+
+      // 2. Delete related field options if applicable
+      await tx.delete(fieldOptions).where(
+        and(
+          eq(fieldOptions.fieldId, fieldId),
+          eq(fieldOptions.siteId, siteId),
+          eq(fieldOptions.organisationId, secure.organisationId)
+        )
+      )
+
+      // 3. Delete the field
+      const [deletedField] = await tx
+        .delete(fields)
+        .where(
+          and(
+            eq(fields.id, fieldId),
+            eq(fields.siteId, siteId),
+            eq(fields.organisationId, secure.organisationId)
+          )
+        )
+        .returning()
+
+      return deletedField
+    })
+  } catch (error) {
+    console.error("Error deleting field:", error)
+    if (error instanceof Error && error.message.includes("foreign key constraint")) {
+      throw createError({
+        statusCode: 409,
+        statusMessage: "Cannot delete field because it has related data."
+      })
+    }
+
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Internal Server Error"
+    })
+  }
+}) 


### PR DESCRIPTION
# Add validation for site deletion to prevent orphaned data

## What Changed

This PR enhances our deletion operations with proper validation and error handling to maintain data integrity:

- Added new delete handlers for component fields with permission checks and related data cleanup
- Added new delete handlers for site fields with similar validation and cleanup logic
- Enhanced site deletion validation to check for content references in stories, components, and component fields

## Why This Change Matters

These improvements are critical for maintaining data integrity throughout our system. Without proper validation:

- Orphaned data could remain in the database after deletions
- Foreign key constraints might cause unexpected errors
- Users could potentially delete resources without proper permissions

The enhanced validation ensures a cleaner database, better error handling, and a more robust user experience.

## Implementation Details

- Added comprehensive validation before deletion operations
- Implemented proper error handling with appropriate HTTP status codes
- Ensured deletion of related data (like field options) when parent resources are removed
- Added checks for content references to prevent deletion when dependencies exist

## Notes for Reviewers

Please pay special attention to the validation logic in the site deletion handler, as this is the most complex change and prevents potential data integrity issues.