### PR TITLE
Add search filter to Add Block modal

### DIFF
--- a/app/components/d-input/index.vue
+++ b/app/components/d-input/index.vue
@@ -55,6 +55,14 @@ const [model, modifiers] = defineModel<string | number>({
     return value
   }
 })
+
+const inputElement = ref<HTMLInputElement | null>(null)
+
+defineExpose({
+  focus: () => {
+    inputElement.value?.focus()
+  }
+})
 </script>
 
 <template>
@@ -79,6 +87,7 @@ const [model, modifiers] = defineModel<string | number>({
       </template>
     </div>
     <input
+      ref="inputElement"
       :id="name"
       :name="name"
       :type="type"

--- a/app/components/d-modal.vue
+++ b/app/components/d-modal.vue
@@ -52,19 +52,19 @@ function confirm() {
       <!-- Conditionally render the overlay and content -->
       <div
         v-if="open"
-        class="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto"
+        class="fixed inset-0 z-50 flex justify-center overflow-y-auto pt-30"
       >
         <DialogOverlay
           class="data-[state=open]:animate-overlayShow bg-neutral-inverse/5 fixed inset-0 z-10 backdrop-blur-xs"
         />
         <DialogContent
-          class="data-[state=open]:animate-contentShow relative z-20 flex w-full flex-col rounded-lg bg-neutral shadow-lg outline-none"
+          class="data-[state=open]:animate-contentShow bg-neutral relative z-20 flex h-fit w-full flex-col rounded-lg shadow-lg outline-none"
           :class="[sizeClasses[size], 'max-h-[80vh]']"
         >
           <!-- Header -->
           <div class="border-neutral flex items-center justify-between border-b p-5">
             <div>
-              <DialogTitle class="text-lg font-semibold text-neutral">
+              <DialogTitle class="text-neutral text-lg font-semibold">
                 {{ title }}
               </DialogTitle>
               <DialogDescription


### PR DESCRIPTION
- Filters available blocks by display name or component name.
- Autofocuses the search input when the modal opens.
- Resets search term on modal close.
- Includes minor style adjustments to the modal component.

closes #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated a dynamic search field within the add modal, enabling users to filter available components effortlessly.
  - Enabled automatic focusing on input fields, ensuring a swift and intuitive experience when interacting with modals.
  
- **Style**
  - Refined modal layout with enhanced vertical alignment and increased top padding, delivering a cleaner and more modern presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->