### PR TITLE
fix: copy link/section/custom fields when adding language instead of …

### DIFF
--- a/server/api/sites/[siteId]/languages/index.post.ts
+++ b/server/api/sites/[siteId]/languages/index.post.ts
@@ -20,7 +20,10 @@ const nonTranslatableFields = [
   "number",
   "datetime",
   "option",
-  "options"
+  "options",
+  "link",
+  "section",
+  "custom"
 ] as const
 
 async function processBlockContent(


### PR DESCRIPTION
…blanking them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed translation handling for link, section, and custom field types to ensure they are properly preserved from default content instead of being initialized as blank during translation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->