### PR TITLE
fix: MCP block operations for multi-language and multi-field stories

### DIFF
--- a/app/components/d-page/header/index.vue
+++ b/app/components/d-page/header/index.vue
@@ -18,32 +18,14 @@ const initials = computed(() => {
   return (name[0]?.charAt(0) || "") + (name[1]?.charAt(0) || "")
 })
 
-const { data: site } = await useAsyncData(
-  `/api/sites`,
-  async () => {
-    if (!siteId.value) return undefined
-
-    const data = await $fetch(`/api/sites/${siteId.value}`)
-    return data
-  },
-  {
-    watch: [siteId]
-  }
+const { data: site } = await useFetch(
+  () => siteId.value ? `/api/sites/${siteId.value}` : null
 )
 
-const { data: story } = await useAsyncData(
-  "/api/sites/stories",
-  async () => {
-    if (!siteId.value || (!storyId.value && !folderId.value)) return undefined
-
-    const data = await $fetch(
-      `/api/sites/${siteId.value}/stories/${storyId.value || folderId.value}`
-    )
-    return data
-  },
-  {
-    watch: [storyId, folderId]
-  }
+const { data: story } = await useFetch(
+  () => (siteId.value && (storyId.value || folderId.value))
+    ? `/api/sites/${siteId.value}/stories/${storyId.value || folderId.value}`
+    : null
 )
 
 const breadcrumbContainer = ref<HTMLElement | undefined>()
@@ -90,8 +72,8 @@ const visibleBreadcrumbItems = computed(() => {
           ref="breadcrumbContainer"
           class="flex grow items-center gap-2"
         >
-          <template v-if="story">
-            <template v-if="story.parents.length > maxVisibleBreadcrumbItems">
+          <template v-if="story && (storyId || folderId)">
+            <template v-if="(story.parents?.length || 0) > maxVisibleBreadcrumbItems">
               <DPageHeaderSeparator />
               <span class="text-neutral-subtle">...</span>
             </template>

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -159,8 +159,8 @@ export class ZeitwordApi {
   }
 
   private async fetchStoryContent(siteId: string, storyId: string): Promise<Record<string, any>> {
-    const story = await this.getStory(siteId, storyId, { full: true })
-    return this.normalizeContent((story as any)?.content || {})
+    const content = await this.request<Record<string, any>>(`/api/sites/${siteId}/stories/${storyId}/content`)
+    return this.normalizeContent(content || {})
   }
 
   private async putStoryContent(siteId: string, storyId: string, content: Record<string, any>): Promise<any> {
@@ -168,6 +168,43 @@ export class ZeitwordApi {
       method: "PUT",
       body: { content }
     })
+  }
+
+  private getBlocksArray(langContent: Record<string, any>, fieldKey?: string): any[] {
+    if (fieldKey) {
+      if (!Array.isArray(langContent[fieldKey])) {
+        langContent[fieldKey] = []
+      }
+      return langContent[fieldKey]
+    }
+    if (Array.isArray(langContent.blocks)) {
+      return langContent.blocks
+    }
+    const blocksKeys = Object.keys(langContent).filter(
+      (k) => Array.isArray(langContent[k]) && langContent[k].some((b: any) => this.isBlock(b))
+    )
+    if (blocksKeys.length === 1) {
+      return langContent[blocksKeys[0]]
+    }
+    if (blocksKeys.length > 1) {
+      throw new Error(
+        `Multiple blocks-type fields found (${blocksKeys.join(", ")}). Please specify a fieldKey.`
+      )
+    }
+    langContent.blocks = []
+    return langContent.blocks
+  }
+
+  private findBlockArrayContaining(langContent: Record<string, any>, blockId: string): { array: any[]; key: string } | null {
+    for (const key of Object.keys(langContent)) {
+      if (Array.isArray(langContent[key])) {
+        const idx = langContent[key].findIndex((b: any) => b.id === blockId)
+        if (idx !== -1) {
+          return { array: langContent[key], key }
+        }
+      }
+    }
+    return null
   }
 
   private regenerateOrders(blocks: any[]): void {
@@ -327,15 +364,15 @@ export class ZeitwordApi {
     storyId: string,
     language: string,
     block: { componentId: string; content: Record<string, any> },
-    position: string = "end"
+    position: string = "end",
+    fieldKey?: string
   ) {
     await this.validateLanguage(siteId, language)
     const storyContent = await this.fetchStoryContent(siteId, storyId)
 
-    if (!storyContent[language]) storyContent[language] = { blocks: [] }
-    if (!Array.isArray(storyContent[language].blocks)) storyContent[language].blocks = []
+    if (!storyContent[language]) storyContent[language] = {}
 
-    const blocks = storyContent[language].blocks
+    const blocks = this.getBlocksArray(storyContent[language], fieldKey)
     const nameMap = await this.getComponentNameMap(siteId)
     const newBlock: any = {
       id: uuidv7(),
@@ -377,17 +414,17 @@ export class ZeitwordApi {
     await this.validateLanguage(siteId, language)
     const storyContent = await this.fetchStoryContent(siteId, storyId)
 
-    if (!storyContent[language]?.blocks) {
-      throw new Error(`No blocks found for language "${language}"`)
+    const langContent = storyContent[language]
+    if (!langContent) {
+      throw new Error(`No content found for language "${language}"`)
     }
 
-    const blocks = storyContent[language].blocks
-    const block = blocks.find((b: any) => b.id === blockId)
-    if (!block) throw new Error(`Block ${blockId} not found`)
+    const found = this.findBlockArrayContaining(langContent, blockId)
+    if (!found) throw new Error(`Block ${blockId} not found`)
 
+    const block = found.array.find((b: any) => b.id === blockId)
     block.content = blockContent
 
-    // Enrich nested blocks (logos, cards, badges, etc.) with id/order/componentName
     for (const value of Object.values(blockContent)) {
       if (Array.isArray(value)) {
         await this.enrichBlocks(siteId, value)
@@ -407,15 +444,16 @@ export class ZeitwordApi {
     await this.validateLanguage(siteId, language)
     const storyContent = await this.fetchStoryContent(siteId, storyId)
 
-    if (!storyContent[language]?.blocks) {
-      throw new Error(`No blocks found for language "${language}"`)
+    const langContent = storyContent[language]
+    if (!langContent) {
+      throw new Error(`No content found for language "${language}"`)
     }
 
-    const blocks = storyContent[language].blocks
-    const idx = blocks.findIndex((b: any) => b.id === blockId)
-    if (idx === -1) throw new Error(`Block ${blockId} not found`)
+    const found = this.findBlockArrayContaining(langContent, blockId)
+    if (!found) throw new Error(`Block ${blockId} not found`)
 
-    blocks.splice(idx, 1)
+    const idx = found.array.findIndex((b: any) => b.id === blockId)
+    found.array.splice(idx, 1)
 
     await this.putStoryContent(siteId, storyId, storyContent)
     return { success: true, storyId, blockId }
@@ -431,14 +469,16 @@ export class ZeitwordApi {
     await this.validateLanguage(siteId, language)
     const storyContent = await this.fetchStoryContent(siteId, storyId)
 
-    if (!storyContent[language]?.blocks) {
-      throw new Error(`No blocks found for language "${language}"`)
+    const langContent = storyContent[language]
+    if (!langContent) {
+      throw new Error(`No content found for language "${language}"`)
     }
 
-    const blocks = storyContent[language].blocks
-    const idx = blocks.findIndex((b: any) => b.id === blockId)
-    if (idx === -1) throw new Error(`Block ${blockId} not found`)
+    const found = this.findBlockArrayContaining(langContent, blockId)
+    if (!found) throw new Error(`Block ${blockId} not found`)
 
+    const blocks = found.array
+    const idx = blocks.findIndex((b: any) => b.id === blockId)
     const [block] = blocks.splice(idx, 1)
 
     if (position === "start") {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -759,7 +759,9 @@ Position options:
 - "end" (default): Add at the end of the blocks array
 - "start": Add at the beginning
 - "before:blockId": Add before a specific existing block
-- "after:blockId": Add after a specific existing block`,
+- "after:blockId": Add after a specific existing block
+
+IMPORTANT: If the story's component has multiple blocks-type fields (e.g. "links", "buttons", "banner"), you MUST specify fieldKey to target the correct field. If only one blocks-type field exists, it will be auto-detected.`,
       inputSchema: {
         siteId: z.string().describe("The UUID of the site"),
         storyId: z.string().describe("The UUID of the story"),
@@ -769,12 +771,16 @@ Position options:
         position: z
           .string()
           .optional()
-          .describe('Where to insert: "end" (default), "start", "before:blockId", "after:blockId"')
+          .describe('Where to insert: "end" (default), "start", "before:blockId", "after:blockId"'),
+        fieldKey: z
+          .string()
+          .optional()
+          .describe('The field key to add the block to (e.g. "banner", "links", "buttons"). Required when the component has multiple blocks-type fields.')
       },
       annotations: { destructiveHint: false, openWorldHint: false }
     },
-    async ({ siteId, storyId, language, componentId, content, position }) => {
-      const result = await api.addBlock(siteId, storyId, language, { componentId, content }, position)
+    async ({ siteId, storyId, language, componentId, content, position, fieldKey }) => {
+      const result = await api.addBlock(siteId, storyId, language, { componentId, content }, position, fieldKey)
       return textResult(formatJson(result))
     }
   )

--- a/server/api/sites/[siteId]/stories/[storyId]/content.get.ts
+++ b/server/api/sites/[siteId]/stories/[storyId]/content.get.ts
@@ -1,0 +1,31 @@
+import { eq, and } from "drizzle-orm"
+import { stories } from "~~/server/database/schema"
+
+export default defineEventHandler(async (event) => {
+  const { organisationId } = await requireAuth(event)
+
+  const siteId = getRouterParam(event, "siteId")
+  const storyId = getRouterParam(event, "storyId")
+
+  if (!siteId || !storyId) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid ID" })
+  }
+
+  const [story] = await useDrizzle()
+    .select({ content: stories.content })
+    .from(stories)
+    .where(
+      and(
+        eq(stories.id, storyId),
+        eq(stories.siteId, siteId),
+        eq(stories.organisationId, organisationId)
+      )
+    )
+    .limit(1)
+
+  if (!story) {
+    throw createError({ statusCode: 404, statusMessage: "Story not found" })
+  }
+
+  return story.content
+})


### PR DESCRIPTION
- Add raw content endpoint (GET /stories/:id/content) that returns unmerged DB content so MCP read-modify-write works for all languages
- MCP fetchStoryContent now uses raw endpoint instead of editor endpoint which only returned the selected language's merged content
- Add fieldKey param to addBlock so blocks go into the correct field (e.g. banner, links) instead of always defaulting to blocks
- updateBlock/removeBlock/moveBlock now search all array fields for the target block instead of hardcoding .blocks
- Fix breadcrumb nav: replace stale useAsyncData with useFetch, guard story breadcrumb on route params

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to target specific block fields when managing blocks, enabling support for components with multiple block-type fields (e.g., banners, links, buttons).

* **Bug Fixes**
  * Improved data fetching reliability for story and site information with better handling of missing parameters.
  * Enhanced breadcrumb navigation resilience to prevent display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->